### PR TITLE
Add bin bash

### DIFF
--- a/github-downloader.sh
+++ b/github-downloader.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #####################################################
 #  Download Specific folders from Github using SVN
 #  


### PR DESCRIPTION
The shell redirect seems to only available for bash, so bin bash is a better way to assure the bash shell is used to run the script.